### PR TITLE
Allow theme selection

### DIFF
--- a/netrun/bin/config.pl
+++ b/netrun/bin/config.pl
@@ -9,6 +9,10 @@ $run_dir='/srv/netrun';
 $url_dir='/netrun';
 $end_page='<hr>
 <p align=right>
+<select id="theme">
+<option value="light">Light Theme</option>
+<option value="dark">Dark Theme</option>
+</select>
 <a href="mailto:lawlor@alaska.edu">Dr. Lawlor</a>, 
 <a href="http://www.cs.uaf.edu/">CS</a>, 
 <a href="http://www.uaf.edu/">UAF</a> 

--- a/netrun/bin/run.cgi
+++ b/netrun/bin/run.cgi
@@ -216,24 +216,61 @@ function startupCode() {
 	updateButton('input');
 	updateButton('options');
 	resizeForm();
+
+	// Theme selection
+	var themeSelect = document.getElementById('theme');
+	var selectedTheme = window.localStorage.theme || 'light';
+	themeSelect.value = selectedTheme;
+	themeSelect.addEventListener('change', () => {
+		window.localStorage.theme = themeSelect.value;
+		if (themeSelect.value === 'light') {
+			document.body.classList.remove('dark');
+			editor.setTheme('ace/theme/github');
+		} else {
+			document.body.classList.add('dark');
+    editor.setTheme('ace/theme/twilight');
+		}
+	})
 }
 
 //]]></script>
 
 <style type='text/css' media='screen'>
-body,input,textarea, button, select {
+body.dark, .dark input, .dark textarea, .dark button, .dark select {
 	color: rgb(200,200,200);
 }
-a:link { color: rgb(100,100,255); }
-a:visited { color: rgb(200,0,200); }
-body{ 
+.dark a:link { color: rgb(100,100,255); }
+.dark a:visited { color: rgb(200,0,200); }
+body.dark{ 
 	background-color: #141414;
 }
-input, textarea {
+.dark input, .dark textarea {
 	background-color: #202020;
 }
-input[type=submit],input[type=text], select {
+.dark input[type=submit], .dark input[type=text], .dark select {
 	background-color: #301430;
+}
+
+/* Table styles */
+td.default { /* Default style for output */
+	background-color: #CCCCCC;
+}
+td.error { /* Errors and bad diffs */
+	background-color: #FF8888;
+}
+td.success { /* grade_done */
+	background-color: #88ffff;
+}
+
+/* Dark mode tables */
+.dark td.default { /* Default style for output */
+	background-color: #404040;
+}
+.dark td.error { /* Errors and bad diffs */
+	background-color: #800000;
+}
+.dark td.success { /* grade_done */
+	background-color: #00A080;
 }
 
 input, textarea, pre {
@@ -606,7 +643,11 @@ sub print_main_form {
 
     var editor = ace.edit("ace_editor");
     editor.setOptions({fontSize:"100%"});
-    editor.setTheme("ace/theme/twilight");
+		if (window.localStorage.theme === 'dark) {
+    	editor.setTheme("ace/theme/twilight");
+		} else {
+		  editor.setTheme("ace/theme/github");
+		}
     editor.setShowPrintMargin(false);
     editor.setShowInvisibles(false);
     editor.getSession().setMode("ace/mode/c_cpp");
@@ -2014,7 +2055,7 @@ sub my_sysuser {
 	
 	if ($res != 0) {
 		print $q->hr,$q->h2("$what Error:");
-		my_prefile($outfile,'-bg','#FF8888');
+		my_prefile($outfile,'-bg','error');
 		print "While running command '$cmd' with input file '$src':";
 		my_prefile($src,'-line');
 		exit(0);
@@ -2035,7 +2076,7 @@ sub my_prefile {
 	my $src=shift;
 	my $linePrint=0;
 	my $lineNo=0;
-	my $bgColor="#404040";
+	my $bgColor="default";
 	while (@_) {
 		my $arg=shift;
 		if ($arg eq "-line") {$linePrint=1;}
@@ -2057,7 +2098,7 @@ sub my_prefile {
 		print"</PRE></TD><TD>";
 	}
 	
-	print '<TD BGCOLOR="'.$bgColor.'"><PRE>';
+	print '<TD CLASS="'.$bgColor.'"><PRE>';
 	my $line;
 	open(F,"<$src") or err("Could not open file '$src'");
 	foreach $line (<F>) {

--- a/netrun/bin/run.cgi
+++ b/netrun/bin/run.cgi
@@ -228,7 +228,7 @@ function startupCode() {
 			editor.setTheme('ace/theme/github');
 		} else {
 			document.body.classList.add('dark');
-    editor.setTheme('ace/theme/twilight');
+			editor.setTheme('ace/theme/twilight');
 		}
 	})
 }
@@ -643,11 +643,11 @@ sub print_main_form {
 
     var editor = ace.edit("ace_editor");
     editor.setOptions({fontSize:"100%"});
-		if (window.localStorage.theme === 'dark) {
-    	editor.setTheme("ace/theme/twilight");
-		} else {
-		  editor.setTheme("ace/theme/github");
-		}
+    if (window.localStorage.theme === 'dark) {
+      editor.setTheme("ace/theme/twilight");
+    } else {
+      editor.setTheme("ace/theme/github");
+    }
     editor.setShowPrintMargin(false);
     editor.setShowInvisibles(false);
     editor.getSession().setMode("ace/mode/c_cpp");

--- a/netrun/bin/runt.cgi
+++ b/netrun/bin/runt.cgi
@@ -216,24 +216,61 @@ function startupCode() {
 	updateButton('input');
 	updateButton('options');
 	resizeForm();
+
+	// Theme selection
+	var themeSelect = document.getElementById('theme');
+	var selectedTheme = window.localStorage.theme || 'light';
+	themeSelect.value = selectedTheme;
+	themeSelect.addEventListener('change', () => {
+		window.localStorage.theme = themeSelect.value;
+		if (themeSelect.value === 'light') {
+			document.body.classList.remove('dark');
+			editor.setTheme('ace/theme/github');
+		} else {
+			document.body.classList.add('dark');
+    	Theme('ace/theme/twilight');
+		}
+	})
 }
 
 //]]></script>
 
 <style type='text/css' media='screen'>
-body,input,textarea, button, select {
+body.dark, .dark input, .dark textarea, .dark button, .dark select {
 	color: rgb(200,200,200);
 }
-a:link { color: rgb(100,100,255); }
-a:visited { color: rgb(200,0,200); }
-body{ 
+.dark a:link { color: rgb(100,100,255); }
+.dark a:visited { color: rgb(200,0,200); }
+body.dark{ 
 	background-color: #141414;
 }
-input, textarea {
+.dark input, .dark textarea {
 	background-color: #202020;
 }
-input[type=submit],input[type=text], select {
+.dark input[type=submit], .dark input[type=text], .dark select {
 	background-color: #301430;
+}
+
+/* Table styles */
+td.default { /* Default style for output */
+	background-color: #CCCCCC;
+}
+td.error { /* Errors and bad diffs */
+	background-color: #FF8888;
+}
+td.success { /* grade_done */
+	background-color: #88ffff;
+}
+
+/* Dark mode tables */
+.dark td.default { /* Default style for output */
+	background-color: #404040;
+}
+.dark td.error { /* Errors and bad diffs */
+	background-color: #800000;
+}
+.dark td.success { /* grade_done */
+	background-color: #00A080;
 }
 
 input, textarea, pre {
@@ -606,7 +643,11 @@ sub print_main_form {
 
     var editor = ace.edit("ace_editor");
     editor.setOptions({fontSize:"100%"});
-    editor.setTheme("ace/theme/twilight");
+		if (window.localStorage.theme === 'dark) {
+    	editor.setTheme("ace/theme/twilight");
+		} else {
+		  editor.setTheme("ace/theme/github");
+		}
     editor.setShowPrintMargin(false);
     editor.setShowInvisibles(false);
     editor.getSession().setMode("ace/mode/c_cpp");
@@ -2014,7 +2055,7 @@ sub my_sysuser {
 	
 	if ($res != 0) {
 		print $q->hr,$q->h2("$what Error:");
-		my_prefile($outfile,'-bg','#FF8888');
+		my_prefile($outfile,'-bg','error');
 		print "While running command '$cmd' with input file '$src':";
 		my_prefile($src,'-line');
 		exit(0);
@@ -2035,7 +2076,7 @@ sub my_prefile {
 	my $src=shift;
 	my $linePrint=0;
 	my $lineNo=0;
-	my $bgColor="#404040";
+	my $bgColor="default";
 	while (@_) {
 		my $arg=shift;
 		if ($arg eq "-line") {$linePrint=1;}
@@ -2057,7 +2098,7 @@ sub my_prefile {
 		print"</PRE></TD><TD>";
 	}
 	
-	print '<TD BGCOLOR="'.$bgColor.'"><PRE>';
+	print '<TD CLASS="'.$bgColor.'"><PRE>';
 	my $line;
 	open(F,"<$src") or err("Could not open file '$src'");
 	foreach $line (<F>) {

--- a/netrun/bin/runt.cgi
+++ b/netrun/bin/runt.cgi
@@ -228,7 +228,7 @@ function startupCode() {
 			editor.setTheme('ace/theme/github');
 		} else {
 			document.body.classList.add('dark');
-    	Theme('ace/theme/twilight');
+			Theme('ace/theme/twilight');
 		}
 	})
 }
@@ -643,11 +643,11 @@ sub print_main_form {
 
     var editor = ace.edit("ace_editor");
     editor.setOptions({fontSize:"100%"});
-		if (window.localStorage.theme === 'dark) {
-    	editor.setTheme("ace/theme/twilight");
-		} else {
-		  editor.setTheme("ace/theme/github");
-		}
+    if (window.localStorage.theme === 'dark) {
+      editor.setTheme("ace/theme/twilight");
+    } else {
+      editor.setTheme("ace/theme/github");
+    }
     editor.setShowPrintMargin(false);
     editor.setShowInvisibles(false);
     editor.getSession().setMode("ace/mode/c_cpp");

--- a/netrun/support/project/netrun/grade_util.sh
+++ b/netrun/support/project/netrun/grade_util.sh
@@ -16,7 +16,7 @@ grep -a -v TraceASM $0.out.orig > $0.out
 
 # Exit while complaining about $0.diffs
 bad_diffs() {
-	echo '<TABLE><TR><TD BGCOLOR="#800000">'
+	echo '<TABLE><TR><TD CLASS="error">'
 	echo "Your output for $desc is not quite right.  For the input:"
 	echo "$in" | netrun/filter_htmlpre.pl 
 	echo "I expected the output:"
@@ -192,7 +192,7 @@ double_secret() {
 grade_done() {
 	# The good "GRADEVAL" argument is found by netrun, and stored for grading.
 	# Subtle: student code can't just printf this, because netrun/filter_htmlpre escapes it.
-	echo '<TABLE><TR><TD BGCOLOR="#00A080" STYLE="color:#FFFFFF" GRADEVAL="@<YES!>&">'
+	echo '<TABLE><TR><TD CLASS="success" STYLE="color:#FFFFFF" GRADEVAL="@<YES!>&">'
 	echo "$desc output looks OK!"
 	echo '</TD></TR></TABLE>'
 }

--- a/netrun/support/project/netrun/run.sh
+++ b/netrun/support/project/netrun/run.sh
@@ -22,10 +22,10 @@ if [ -s out ]
 then
 	echo "Executing $desc: $@ <br>"
 	
-	color="#202020"
-	[ $res -ne 0 ] && color="#880000"
+	color="default"
+	[ $res -ne 0 ] && color="error"
 
-	echo '<TABLE><TR><TD BGCOLOR="'$color'">
+	echo '<TABLE><TR><TD CLASS="'$color'">
 <! @NetRun/'$desc'@ begin >'
 #  Sadly, -c fails on IRIX:
 #	cat out | head -c 20000 | head -n 200 > out_lil
@@ -43,7 +43,7 @@ then
 	
 	echo '<TABLE><TR><TD VALIGN=top><PRE>'
 	cat $src | netrun/filter_lineno.pl
-	echo '</PRE></TD><TD VALIGN=top BGCOLOR="'$color'">'
+	echo '</PRE></TD><TD VALIGN=top CLASS="'$color'">'
 	cat $src | netrun/filter_htmlpre.pl
 	echo '</TD></TR></TABLE>'
 fi


### PR DESCRIPTION
This PR allows users of NetRun to choose the theme that they would like to use. Dark mode stylings have been moved under a new class, `dark`, that when present on the body tag will make the page go into dark mode. A few things to be noted:
- I've not tested this due to not having knowledge on how NetRun should be set up.
- Hard-coded colour values in various shell files have been replaced with their classname counterpart - `.success`, `.error`, and `.default` have been added for styling output tables.
- As noted in the CS server, the JS and CSS has not been migrated into separate files, though if requested I can do that as well.