### PR TITLE
Language-aware syntax highlighting

### DIFF
--- a/netrun/bin/run.cgi
+++ b/netrun/bin/run.cgi
@@ -235,6 +235,46 @@ function startupCode() {
 		updateTheme(); // change theme
 	})
 	updateTheme(); // set initial theme
+
+
+	// Editor syntax highlighting
+	var langSelect = document.getElementsByName('lang')[0] // There will only ever be one input with this name
+	var langMap = { // Map the selected language to an ace editor mode
+		'C++': 'ace/mode/c_cpp',
+		'C++0x': 'ace/mode/c_cpp',
+		'C++14': 'ace/mode/c_cpp',
+		'C++17': 'ace/mode/c_cpp',
+		'C': 'ace/mode/c_cpp',
+		'Assembly-NASM': 'ace/mode/assembly_x86',
+		'Assembly': 'ace/mode/assembly_x86',
+		'Fortran 77': 'ace/mode/plain_text',
+		'OpenMP': 'ace/mode/c_cpp',
+		'MPI': 'ace/mode/c_cpp',
+		'CUDA': 'ace/mode/c_cpp',
+		'GPGPU': 'ace/mode/c_cpp',
+		'CBMC': 'ace/mode/c_cpp',
+		'Python': 'ace/mode/python',
+		'Python3': 'ace/mode/python',
+		'Perl': 'ace/mode/perl',
+		'Postscript': 'ace/mode/plain_text',
+		'PHP': 'ace/mode/php',
+		'Scheme': 'ace/mode/scheme',
+		'JavaScript': 'ace/mode/javascript',
+		'Ruby': 'ace/mode/ruby',
+		'Bash': 'ace/mode/sh',
+		'Prolog': 'ace/mode/prolog',
+		'vhdl': 'ace/mode/vhdl'
+	}
+
+	function updateLanguage() { // Update the ace editor mode to match the selected language
+		var lang = langSelect.value;
+		editor.getSession().setMode(langMap[lang]);
+	}
+
+	langSelect.addEventListener('change', () => {
+		updateLanguage();
+	})
+	updateLanguage();
 }
 
 //]]></script>
@@ -660,7 +700,6 @@ sub print_main_form {
     }
     editor.setShowPrintMargin(false);
     editor.setShowInvisibles(false);
-    editor.getSession().setMode("ace/mode/c_cpp");
     editor.getSession().setUseWrapMode(false);
     editor.getSession().setUseWorker(false);
     editor.getSession().setUseSoftTabs(false);

--- a/netrun/bin/run.cgi
+++ b/netrun/bin/run.cgi
@@ -236,7 +236,6 @@ function startupCode() {
 	})
 	updateTheme(); // set initial theme
 
-
 	// Editor syntax highlighting
 	var langSelect = document.getElementsByName('lang')[0] // There will only ever be one input with this name
 	var langMap = { // Map the selected language to an ace editor mode

--- a/netrun/bin/runt.cgi
+++ b/netrun/bin/runt.cgi
@@ -235,6 +235,46 @@ function startupCode() {
 		updateTheme(); // change theme
 	})
 	updateTheme(); // set initial theme
+
+
+	// Editor syntax highlighting
+	var langSelect = document.getElementsByName('lang')[0] // There will only ever be one input with this name
+	var langMap = { // Map the selected language to an ace editor mode
+		'C++': 'ace/mode/c_cpp',
+		'C++0x': 'ace/mode/c_cpp',
+		'C++14': 'ace/mode/c_cpp',
+		'C++17': 'ace/mode/c_cpp',
+		'C': 'ace/mode/c_cpp',
+		'Assembly-NASM': 'ace/mode/assembly_x86',
+		'Assembly': 'ace/mode/assembly_x86',
+		'Fortran 77': 'ace/mode/plain_text',
+		'OpenMP': 'ace/mode/c_cpp',
+		'MPI': 'ace/mode/c_cpp',
+		'CUDA': 'ace/mode/c_cpp',
+		'GPGPU': 'ace/mode/c_cpp',
+		'CBMC': 'ace/mode/c_cpp',
+		'Python': 'ace/mode/python',
+		'Python3': 'ace/mode/python',
+		'Perl': 'ace/mode/perl',
+		'Postscript': 'ace/mode/plain_text',
+		'PHP': 'ace/mode/php',
+		'Scheme': 'ace/mode/scheme',
+		'JavaScript': 'ace/mode/javascript',
+		'Ruby': 'ace/mode/ruby',
+		'Bash': 'ace/mode/sh',
+		'Prolog': 'ace/mode/prolog',
+		'vhdl': 'ace/mode/vhdl'
+	}
+
+	function updateLanguage() { // Update the ace editor mode to match the selected language
+		var lang = langSelect.value;
+		editor.getSession().setMode(langMap[lang]);
+	}
+
+	langSelect.addEventListener('change', () => {
+		updateLanguage();
+	})
+	updateLanguage();
 }
 
 //]]></script>
@@ -660,7 +700,6 @@ sub print_main_form {
     }
     editor.setShowPrintMargin(false);
     editor.setShowInvisibles(false);
-    editor.getSession().setMode("ace/mode/c_cpp");
     editor.getSession().setUseWrapMode(false);
     editor.getSession().setUseWorker(false);
     editor.getSession().setUseSoftTabs(false);

--- a/netrun/bin/runt.cgi
+++ b/netrun/bin/runt.cgi
@@ -236,7 +236,6 @@ function startupCode() {
 	})
 	updateTheme(); // set initial theme
 
-
 	// Editor syntax highlighting
 	var langSelect = document.getElementsByName('lang')[0] // There will only ever be one input with this name
 	var langMap = { // Map the selected language to an ace editor mode


### PR DESCRIPTION
This pull request adds functionality that allows the ace editor to respond to changes in the selected language within NetRun. This provides a much better user experience while editing, and additional functionality such as code folding is automatically enabled for supported languages. Any languages that the ace editor does not support default to plaintext editing, as to avoid false positives when attempting syntax highlighting with another language.

Notes on this pull request:
- This pull request has been tested to the best of my ability, but setting up NetRun in a testing environment has proven quite difficult and I did not have the backend fully functional - however, as this PR is frontend-only this shouldn't impact the features added. In the future it may be beneficial to create a development Docker image or similar.
- netrun/bin/runh.cgi has not been updated as it appears to not have been maintained recently and doesn't have base theme support - I'm also not familiar with its functionality.